### PR TITLE
Set version to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 
-## [3.0.0]() (2023-03-17)
+## [2.0.0]() (2023-03-20)
 
 * Compatibility with Companion 3.0.
 * Support for ATEM Television Studio HD8 and HD8 ISO switchers.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,14 @@
 
 [MixEffect Pro](https://mixeffect.app/) is a professional tool for controlling Blackmagic ATEM switchers from your iPhone or iPad.
 
-This module will allow you to control an instance of [MixEffect Pro](https://mixeffect.app/).
+This module will allow you to control an instance of [MixEffect Pro](https://mixeffect.app/) using Companion 3.0.
 
-## Downloading Companion with the Native MixEffect Module Directly from Bitfocus
+## System Requirements
 
-Version 3.0.0 of the native MixEffect module for Companion is designed for use with Companion 3.0. It will not work with prior versions of Companion 2.4.x
+Version 2.0.0 of the native MixEffect module for Companion is designed for use with Companion 3.0. 
 
-Please see [HELP.md](HELP.md) and [LICENSE](LICENSE) for more information.
+**It will not work with prior versions of Companion 2.4.x.**
+
+This module is optimized for use with MixEffect 1.8.0 and higher.
+
+Please see [the documentation](https://docs.mixeffect.app/automate/osc/companion/native-module) and [LICENSE](LICENSE) for more information.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "tow-mixeffect",
-	"version": "3.0.0",
-	"compatibility": "MixEffect Pro 1.7.3",
+	"version": "2.0.0",
+	"compatibility": "MixEffect Pro 1.8.0",
 	"main": "src/index.js",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
Set package version to 2.0.0 to better align with Companion 3.0 release requirements. Updated README with link to installation instructions on docs.mixeffect.app.