### PR TITLE
MixEffect Module 2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
-## [2.0.3](https://github.com/bitfocus/companion-module-tow-mixeffect/compare/v2.0.2...v2.0.3) (2023-07-15)
+## [2.0.4]() (2024-01-09)
 
+* Fix bug where USK Border Hue Set slider would not appear.
+* Support for ATEM Television Studio 4K8 and 4 M/E Constellation 4K switchers.
+
+## [2.0.3](https://github.com/bitfocus/companion-module-tow-mixeffect/compare/v2.0.2...v2.0.3) (2023-07-15)
 
 ### Bug Fixes
 
@@ -33,20 +37,17 @@
 
 ## [1.1.3](https://github.com/bitfocus/companion-module-tow-mixeffect/compare/v1.1.2...v1.1.3) (2021-12-09)
 
-
 ### Bug Fixes
 
 * **switchers:** various fixes to switch configs ([2eebc09](https://github.com/bitfocus/companion-module-tow-mixeffect/commit/2eebc094f418c8fbaf26f1ed7f6de5517e3dbc89)), closes [#4](https://github.com/bitfocus/companion-module-tow-mixeffect/issues/4) [#5](https://github.com/bitfocus/companion-module-tow-mixeffect/issues/5)
 
 ## [1.1.1](https://github.com/bitfocus/companion-module-tow-mixeffect/compare/v1.1.0...v1.1.1) (2021-11-11)
 
-
 ### Bug Fixes
 
 * **variables:** correct default value keys for mp, me, box and ssrc ([01956e3](https://github.com/bitfocus/companion-module-tow-mixeffect/commit/01956e39fa144c09e9e53b4fb64c7e9a9a92ca99))
 
 # [1.1.0](https://github.com/estilles/companion-module-tow-mixeffect/compare/v1.0.2...v1.1.0) (2021-11-08)
-
 
 ### Bug Fixes
 
@@ -79,7 +80,6 @@
 * **usk:** correct missing 'USK: Chroma Advanced Red Set' action ([ec4e86b](https://github.com/estilles/companion-module-tow-mixeffect/commit/ec4e86bf124da4f1c233b8cb486b991e550e3abf))
 * **usk:** fix missing 'USK: Pattern Size Set' action ([77bf76b](https://github.com/estilles/companion-module-tow-mixeffect/commit/77bf76b32e8e1773ef41ab1e42ba6824daa1be14))
 
-
 ### Features
 
 * **actions:** show 'Selected ...' option when only one option is available ([12c9404](https://github.com/estilles/companion-module-tow-mixeffect/commit/12c9404a9a36b892644ee4ff50b00f1931d67434))
@@ -92,7 +92,6 @@
 
 # [1.1.0-beta.11](https://github.com/estilles/companion-module-tow-mixeffect/compare/v1.1.0-beta.10...v1.1.0-beta.11) (2021-11-07)
 
-
 ### Bug Fixes
 
 * **multiviewer:** correct typo ([b7319f1](https://github.com/estilles/companion-module-tow-mixeffect/commit/b7319f167aceeddcffd3648228babfcf5e98553b))
@@ -103,20 +102,17 @@
 * **preset:** update labels on VFA presets ([34be5f1](https://github.com/estilles/companion-module-tow-mixeffect/commit/34be5f1064c084558f44f2fd01533d11d1a057f3))
 * **preset:** update Transitions presets ([a7891fd](https://github.com/estilles/companion-module-tow-mixeffect/commit/a7891fd1b28f4a31cb3cd557741e2e940519dbc5))
 
-
 ### Features
 
 * **presets:** add multi viewer presets ([b51debf](https://github.com/estilles/companion-module-tow-mixeffect/commit/b51debf474febdb91e3c7dc55decef238bd0900c))
 
 # [1.1.0-beta.10](https://github.com/estilles/companion-module-tow-mixeffect/compare/v1.1.0-beta.9...v1.1.0-beta.10) (2021-11-07)
 
-
 ### Bug Fixes
 
 * **multiviewer:** remove old file ([198f9a8](https://github.com/estilles/companion-module-tow-mixeffect/commit/198f9a87963ddcab9ae504434cdc1cbbbe72685f))
 
 # [1.1.0-beta.9](https://github.com/estilles/companion-module-tow-mixeffect/compare/v1.1.0-beta.8...v1.1.0-beta.9) (2021-11-06)
-
 
 ### Bug Fixes
 
@@ -125,7 +121,6 @@
 
 # [1.1.0-beta.8](https://github.com/estilles/companion-module-tow-mixeffect/compare/v1.1.0-beta.7...v1.1.0-beta.8) (2021-11-06)
 
-
 ### Bug Fixes
 
 * **multiview:** fix typo on advanced layout 4 ([6094847](https://github.com/estilles/companion-module-tow-mixeffect/commit/60948475ff5418bbd852690b056f9615fb72e85a))
@@ -133,13 +128,11 @@
 * **switchers:** change number of aux buses for Constellation 8K to 24 ([7b78f1a](https://github.com/estilles/companion-module-tow-mixeffect/commit/7b78f1a9912b70789618e53237a6301a86344656))
 * **transition:** enable 'Transition: Next' to use the selected USK ([f805483](https://github.com/estilles/companion-module-tow-mixeffect/commit/f805483700558b977519b6f5f56fb85ecae00d8b))
 
-
 ### Features
 
 * **multiviewer:** add select multi viewer variable/action/feedback ([3b3eca5](https://github.com/estilles/companion-module-tow-mixeffect/commit/3b3eca5a9f2582a96990d8fbe5ec5e7991d8de23))
 
 # [1.1.0-beta.7](https://github.com/estilles/companion-module-tow-mixeffect/compare/v1.1.0-beta.6...v1.1.0-beta.7) (2021-11-04)
-
 
 ### Bug Fixes
 
@@ -149,13 +142,11 @@
 * **usk:** correct missing 'USK: Chroma Advanced Red Set' action ([ec4e86b](https://github.com/estilles/companion-module-tow-mixeffect/commit/ec4e86bf124da4f1c233b8cb486b991e550e3abf))
 * **usk:** fix missing 'USK: Pattern Size Set' action ([77bf76b](https://github.com/estilles/companion-module-tow-mixeffect/commit/77bf76b32e8e1773ef41ab1e42ba6824daa1be14))
 
-
 ### Features
 
 * **supersource:** add 'SuperSource: Box Select' action ([117fbe7](https://github.com/estilles/companion-module-tow-mixeffect/commit/117fbe79deac4652aedbe840fce3f766673a1188))
 
 # [1.1.0-beta.6](https://github.com/estilles/companion-module-tow-mixeffect/compare/v1.1.0-beta.5...v1.1.0-beta.6) (2021-11-03)
-
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This module will allow you to control an instance of [MixEffect](https://mixeffe
 
 ## System Requirements
 
-Version 2.0.2 of the native MixEffect module for Companion is designed for use with Companion 3.0.
+Version 2.0.4 of the native MixEffect module for Companion is designed for use with Companion 3.0.
 
 **It will not work with prior versions of Companion 2.4.x.**
 

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -17,6 +17,11 @@ Once OSC is enabled on the MixEffect app you can proceed to configure this modul
 1. the Target IP address (which is the IP of the iOS device running MixEffect), and
 2. the Target Port (which is the port of the switcher's OSC server described above).
 
+If you have the HTTP Feedback server enabled in your Switcher Connection in MixEffect and want to have feedback returned to Companion from your ATEM switcher, follow these steps:
+
+1. Set the HTTP Server Port to the same HTTP Server Port value in your Switcher Connection entry in MixEffect.
+2. Set the Polling Interval in milliseconds. The minimum time value should be 500, but you can increase this number if it leads to better performance in Companion.
+
 ### Actions
 
 We have included a number of actions to help you control MixEffect. There are actions in each of these categories:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tow-mixeffect",
-	"version": "2.0.3",
+	"version": "2.0.4",
 	"compatibility": "MixEffect Pro 1.8.0",
 	"main": "src/index.js",
 	"scripts": {
@@ -22,6 +22,6 @@
 		"semantic-release": "^19.0.3"
 	},
 	"dependencies": {
-		"@companion-module/base": "~1.4.1"
+		"@companion-module/base": "~1.7.0"
 	}
 }

--- a/src/actions/upstreamKeyerActions.js
+++ b/src/actions/upstreamKeyerActions.js
@@ -984,7 +984,15 @@ const upstreamKeyerActions = ({ context }) => {
 
 	actions.uskDVEBorderHueSet = {
 		name: 'USK: DVE Border Hue Set',
-		options: [option.hue, option.usk(context), option.mixEffectBus(context)],
+		options: [
+			option.hue({
+				min: 0,
+				max: 359.9,
+				step: 0.1,
+			}),
+			option.usk(context),
+			option.mixEffectBus(context),
+		],
 		callback: ({ options }) => {
 			context.oscSendPath('/mixeffect/usk/dve/border/parameter/set', [
 				{ type: 'i', value: 8 },

--- a/src/switchers/atem-4-me-constellation-4k.js
+++ b/src/switchers/atem-4-me-constellation-4k.js
@@ -1,0 +1,53 @@
+const { model, audioSource } = require('./types')
+const generator = require('./generators')
+
+const switcher = {
+	id: model.atem4meConstellation4k,
+	label: 'ATEM 4 M/E Constellation 4K',
+	mixEffectBuses: 4,
+	auxBuses: 24,
+	inputs: 40,
+	multiViewers: 4,
+	advancedMultiViewer: true,
+	upstreamKeyers: 16,
+	downstreamKeyers: 4,
+	superSources: 2,
+	superSourceArtBorder: false,
+	macros: 100,
+	mediaPlayers: 4,
+	mediaStills: 64,
+	mediaClips: 4,
+	streaming: false,
+	recording: false,
+	recordISO: false,
+	stinger: true,
+	advancedChromaKeyer: true,
+	fairlightAudio: true,
+}
+
+switcher.videoSources = [
+	...generator.blackSources({ me: switcher.mixEffectBuses }),
+	...generator.videoSources(switcher.inputs, { me: switcher.mixEffectBuses }),
+	...generator.colorBarsSources({ me: switcher.mixEffectBuses }),
+	...generator.colorSources(2, { me: switcher.mixEffectBuses }),
+	...generator.mediaPlayerSources(switcher.mediaPlayers, { me: switcher.mixEffectBuses }),
+	...generator.upstreamKeyMaskSources(switcher.upstreamKeyers),
+	...generator.downstreamKeyMaskSources(switcher.downstreamKeyers),
+	...generator.superSourceSources(switcher.superSources, { me: switcher.mixEffectBuses }),
+	...generator.cleanFeedSources(switcher.mixEffectBuses),
+	...generator.auxiliarySources(switcher.auxBuses),
+	...generator.programSources(switcher.mixEffectBuses),
+	...generator.previewSources(switcher.mixEffectBuses),
+]
+
+switcher.audioSources = [
+	...generator.sdiSources(switcher.inputs),
+	...generator.micSources(1, audioSource.ts),
+	...generator.trsSources(1),
+	...generator.madiSources(32),
+	...generator.mediaPlayerAudioSources(switcher.mediaPlayers),
+]
+
+module.exports = {
+	atem4meConstellation4k: switcher,
+}

--- a/src/switchers/atem-television-studio-4k8.js
+++ b/src/switchers/atem-television-studio-4k8.js
@@ -1,0 +1,55 @@
+const { model, audioSource } = require('./types')
+const generator = require('./generators')
+
+const switcher = {
+	id: model.atemTelevisionStudio4k8,
+	label: 'ATEM Television Studio 4K8',
+	mixEffectBuses: 1,
+	auxBuses: 10,
+	inputs: 8,
+	multiViewers: 1,
+	advancedMultiViewer: true,
+	upstreamKeyers: 4,
+	downstreamKeyers: 2,
+	superSources: 1,
+	superSourceArtBorder: false,
+	macros: 100,
+	mediaPlayers: 2,
+	mediaStills: 20,
+	mediaClips: 2,
+	streaming: true,
+	recording: true,
+	recordISO: false,
+	stinger: true,
+	advancedChromaKeyer: true,
+	fairlightAudio: true,
+}
+
+switcher.videoSources = [
+	...generator.blackSources({ me: switcher.mixEffectBuses }),
+	...generator.videoSources(switcher.inputs, { me: switcher.mixEffectBuses }),
+	...generator.colorBarsSources({ me: switcher.mixEffectBuses }),
+	...generator.colorSources(2, { me: switcher.mixEffectBuses }),
+	...generator.mediaPlayerSources(switcher.mediaPlayers, { me: switcher.mixEffectBuses }),
+	...generator.upstreamKeyMaskSources(switcher.upstreamKeyers),
+	...generator.downstreamKeyMaskSources(switcher.downstreamKeyers),
+	...generator.superSourceSources(switcher.superSources, { me: switcher.mixEffectBuses }),
+	...generator.cleanFeedSources(switcher.mixEffectBuses),
+	...generator.auxiliarySources(switcher.auxBuses),
+	...generator.multiViewerSources(switcher.multiViewers),
+	...generator.programSources(switcher.mixEffectBuses),
+	...generator.previewSources(switcher.mixEffectBuses),
+]
+
+switcher.audioSources = [
+	...generator.sdiSources(switcher.inputs),
+	...generator.micSources(1, audioSource.ts),
+	...generator.trsSources(2),
+	...generator.madiSources(32),
+	...generator.rcaSources(1),
+	...generator.mediaPlayerAudioSources(switcher.mediaPlayers),
+]
+
+module.exports = {
+	atemTelevisionStudio4k8: switcher,
+}

--- a/src/switchers/index.js
+++ b/src/switchers/index.js
@@ -27,6 +27,9 @@ const { atemSdiExtremeIso } = require('./atem-sdi-extreme-iso')
 const { atemTelevisionStudioHd8 } = require('./atem-television-studio-hd8')
 const { atemTelevisionStudioHd8Iso } = require('./atem-television-studio-hd8-iso')
 
+const { atem4meConstellation4k } = require('./atem-4-me-constellation-4k')
+const { atemTelevisionStudio4k8 } = require('./atem-television-studio-4k8')
+
 module.exports = [
 	atemProductionStudio4k,
 
@@ -56,4 +59,7 @@ module.exports = [
 
 	atemTelevisionStudioHd8,
 	atemTelevisionStudioHd8Iso,
+
+	atem4meConstellation4k,
+	atemTelevisionStudio4k8,
 ]

--- a/src/switchers/types.js
+++ b/src/switchers/types.js
@@ -36,6 +36,9 @@ module.exports = {
 
 		atemTelevisionStudioHd8: 26,
 		atemTelevisionStudioHd8Iso: 27,
+
+		atem4meConstellation4k: 30,
+		atemTelevisionStudio4k8: 32,
 	},
 
 	// Video Source Types


### PR DESCRIPTION
* Fix bug where USK Border Hue Set slider would not appear.
* Support for ATEM Television Studio 4K8 and 4 M/E Constellation 4K switchers.
* Increased support for Companion base 1.7 (3.2)