### PR TITLE
Version 2.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-## [3.0.1](https://github.com/bitfocus/companion-module-tow-mixeffect/compare/v3.0.0...v3.0.1) (2024-01-09)
+## [2.0.5]() (2024-05-15)
 
+* Support for ATEM 1 M/E Constellation 4K and 2 M/E Constellation 4K switchers.
+
+## [3.0.1](https://github.com/bitfocus/companion-module-tow-mixeffect/compare/v3.0.0...v3.0.1) (2024-01-09)
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This module will allow you to control an instance of [MixEffect](https://mixeffe
 
 ## System Requirements
 
-Version 2.0.4 of the native MixEffect module for Companion is designed for use with Companion 3.0.
+The native MixEffect module for Companion is designed for use with Companion 3.0.
 
 **It will not work with prior versions of Companion 2.4.x.**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tow-mixeffect",
-	"version": "2.0.4",
+	"version": "2.0.5",
 	"compatibility": "MixEffect Pro 1.8.0",
 	"main": "src/index.js",
 	"scripts": {
@@ -22,6 +22,6 @@
 		"semantic-release": "^19.0.3"
 	},
 	"dependencies": {
-		"@companion-module/base": "~1.7.0"
+		"@companion-module/base": "~1.8.0"
 	}
 }

--- a/src/switchers/index.js
+++ b/src/switchers/index.js
@@ -27,6 +27,8 @@ const { atemSdiExtremeIso } = require('./atem-sdi-extreme-iso')
 const { atemTelevisionStudioHd8 } = require('./atem-television-studio-hd8')
 const { atemTelevisionStudioHd8Iso } = require('./atem-television-studio-hd8-iso')
 
+const { atem1meConstellation4k } = require('./atem-1-me-constellation-4k')
+const { atem2meConstellation4k } = require('./atem-2-me-constellation-4k')
 const { atem4meConstellation4k } = require('./atem-4-me-constellation-4k')
 const { atemTelevisionStudio4k8 } = require('./atem-television-studio-4k8')
 
@@ -60,6 +62,8 @@ module.exports = [
 	atemTelevisionStudioHd8,
 	atemTelevisionStudioHd8Iso,
 
+	atem1meConstellation4k,
+	atem2meConstellation4k,
 	atem4meConstellation4k,
 	atemTelevisionStudio4k8,
 ]

--- a/src/switchers/types.js
+++ b/src/switchers/types.js
@@ -37,6 +37,8 @@ module.exports = {
 		atemTelevisionStudioHd8: 26,
 		atemTelevisionStudioHd8Iso: 27,
 
+		atem1meConstellation4k: 28,
+		atem2meConstellation4k: 29,
 		atem4meConstellation4k: 30,
 		atemTelevisionStudio4k8: 32,
 	},


### PR DESCRIPTION
- Support for ATEM 1 M/E Constellation 4K and 2 M/E Constellation 4K switchers.
- Updated to companion-module/base 1.8.0